### PR TITLE
Add drag-and-drop reordering for games list

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -113,17 +113,45 @@ h1 {
   margin-bottom: 0.75rem;
   background-color: #1a1a1a;
   border-radius: 8px;
-  transition: all 0.3s ease;
+  transition: all 0.2s ease;
   text-align: left;
+  user-select: none;
 }
 
 .game-item:hover {
   background-color: #2a2a2a;
-  transform: translateX(5px);
 }
 
 .game-item.completed {
   opacity: 0.6;
+}
+
+.game-item.dragging {
+  opacity: 0.4;
+  border: 2px dashed #646cff;
+}
+
+.game-item.drag-over {
+  border-top: 3px solid #646cff;
+  margin-top: -3px;
+}
+
+.drag-handle {
+  cursor: grab;
+  font-size: 1.2rem;
+  color: #555;
+  padding: 0 0.25rem;
+  line-height: 1;
+  letter-spacing: 1px;
+  transition: color 0.2s;
+}
+
+.drag-handle:hover {
+  color: #646cff;
+}
+
+.drag-handle:active {
+  cursor: grabbing;
 }
 
 .game-item.completed .game-title {
@@ -183,27 +211,31 @@ h1 {
   .game-item {
     background-color: #f5f5f5;
   }
-  
+
   .game-item:hover {
     background-color: #e0e0e0;
   }
-  
+
   .game-input {
     border-color: #646cff;
   }
-  
+
   .stats {
     border-top-color: #ddd;
   }
-  
+
   .build-info {
     border-top-color: #ddd;
     color: #999;
   }
-  
+
   .current-file-name {
     background-color: #e0e0e0;
     color: #666;
+  }
+
+  .drag-handle {
+    color: #999;
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from 'react'
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { uuidv7 } from 'uuidv7'
 import './App.css'
 import type { Game } from './types'
@@ -21,13 +21,51 @@ function App() {
   const [keyboardVisible, setKeyboardVisible] = useState(false)
   const [focusedIndex, setFocusedIndex] = useState(0)
   const [hasGamepad, setHasGamepad] = useState(false)
+  const [dragIndex, setDragIndex] = useState<number | null>(null)
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
   const saveTimeoutRef = useRef<number | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  // Sort games to display unfinished games first, finished games last
-  const sortedGames = useMemo(() => {
-    return [...games].sort((a, b) => Number(a.completed) - Number(b.completed))
-  }, [games])
+  const handleDragStart = useCallback((index: number, e: React.DragEvent) => {
+    setDragIndex(index)
+    e.dataTransfer.effectAllowed = 'move'
+    e.dataTransfer.setData('text/plain', String(index))
+    // Style the drag image
+    if (e.currentTarget instanceof HTMLElement) {
+      e.currentTarget.classList.add('dragging')
+    }
+  }, [])
+
+  const handleDragOver = useCallback((index: number, e: React.DragEvent) => {
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'move'
+    setDragOverIndex(index)
+  }, [])
+
+  const handleDragEnd = useCallback(() => {
+    setDragIndex(null)
+    setDragOverIndex(null)
+    // Remove dragging class from all items
+    document.querySelectorAll('.dragging').forEach(el => el.classList.remove('dragging'))
+  }, [])
+
+  const handleDrop = useCallback((targetIndex: number, e: React.DragEvent) => {
+    e.preventDefault()
+    const sourceIndex = dragIndex
+    if (sourceIndex === null || sourceIndex === targetIndex) {
+      handleDragEnd()
+      return
+    }
+
+    setGames(prev => {
+      const updated = [...prev]
+      const [moved] = updated.splice(sourceIndex, 1)
+      updated.splice(targetIndex, 0, moved)
+      return updated
+    })
+
+    handleDragEnd()
+  }, [dragIndex, handleDragEnd])
 
   // Helper function to update the file name display
   const updateFileNameDisplay = async () => {
@@ -224,7 +262,7 @@ function App() {
         index++
         
         // Game items (checkbox and delete)
-        for (const game of sortedGames) {
+        for (const game of games) {
           if (index === focusedIndex) {
             toggleGame(game.id)
             return
@@ -274,7 +312,7 @@ function App() {
     const gameCheckboxes = document.querySelectorAll('.game-checkbox')
     const deleteButtons = document.querySelectorAll('.delete-button')
     
-    sortedGames.forEach((_, i) => {
+    games.forEach((_, i) => {
       if (gameCheckboxes[i]) elements.push(gameCheckboxes[i] as HTMLElement)
       if (deleteButtons[i]) elements.push(deleteButtons[i] as HTMLElement)
     })
@@ -287,7 +325,7 @@ function App() {
         el.classList.remove('gamepad-focused')
       }
     })
-  }, [focusedIndex, fileSupported, sortedGames])
+  }, [focusedIndex, fileSupported, games])
 
   return (
     <div className={`app ${hasGamepad ? 'gamepad-mode' : ''}`}>
@@ -335,8 +373,18 @@ function App() {
         {games.length === 0 ? (
           <p className="empty-message">No games yet. Add your first game above!</p>
         ) : (
-          sortedGames.map(game => (
-            <div key={game.id} className={`game-item ${game.completed ? 'completed' : ''}`}>
+          games.map((game, index) => (
+            <div
+              key={game.id}
+              className={`game-item ${game.completed ? 'completed' : ''}${dragIndex === index ? ' dragging' : ''}${dragOverIndex === index && dragIndex !== index ? ' drag-over' : ''}`}
+              draggable
+              onDragStart={(e) => handleDragStart(index, e)}
+              onDragOver={(e) => handleDragOver(index, e)}
+              onDragEnd={handleDragEnd}
+              onDrop={(e) => handleDrop(index, e)}
+              onDragLeave={() => setDragOverIndex(null)}
+            >
+              <span className="drag-handle" title="Drag to reorder">⠿</span>
               <input
                 type="checkbox"
                 checked={game.completed}


### PR DESCRIPTION
## Summary
Implement drag-and-drop functionality to allow users to reorder games in their list. This replaces the previous sorted view (which automatically grouped completed games) with a user-controlled ordering system.

## Key Changes
- **Drag-and-drop handlers**: Added `handleDragStart`, `handleDragOver`, `handleDrop`, and `handleDragEnd` callbacks to manage the drag-and-drop lifecycle
- **State management**: Introduced `dragIndex` and `dragOverIndex` state to track which item is being dragged and where it's being dragged over
- **Visual feedback**: Added CSS classes for dragging state (`.dragging`, `.drag-over`) and a drag handle element with grab/grabbing cursor states
- **Removed auto-sorting**: Eliminated the `sortedGames` memoized value that previously sorted games by completion status; games now maintain user-defined order
- **Drag handle UI**: Added a visual drag handle (⠿) with hover effects to indicate items are draggable
- **CSS refinements**: Updated transition timing (0.3s → 0.2s), removed hover transform effect, added `user-select: none` to prevent text selection during drag, and cleaned up whitespace

## Implementation Details
- Drag operations use the HTML5 Drag and Drop API with `draggable` attribute on game items
- The drag handle provides visual affordance and improves UX by showing users where to grab
- Drop logic reorders the games array by removing the source item and inserting it at the target position
- Light mode support added for the drag handle color
- All gamepad navigation logic updated to reference the unsorted `games` array instead of `sortedGames`

https://claude.ai/code/session_0175EEex1tHRwsowpTzNEbpn